### PR TITLE
🤖: Publish to the gh-pages branch instead of a Pages artifact

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -5,9 +5,9 @@ on:
       - main
   workflow_dispatch:
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  # Publishing to the gh-pages branch is a push to this repository, not a Pages
+  # artifact upload, so this needs contents:write rather than pages/id-token.
+  contents: write
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -32,10 +32,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v6
 
       - name: Create a local tools directory
         run: |
@@ -112,12 +108,13 @@ jobs:
           restore-keys: hugo-
 
       - name: Build
+        # No --baseURL: the value configured in hugo.yml (site config) is already
+        # correct for production, and no longer needs to come from configure-pages.
         run: |
           echo "Building the project..."
           hugo build \
             --gc \
             --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/" \
             --cacheDir "${{ runner.temp }}/hugo_cache"
 
       - name: Cache save
@@ -126,17 +123,20 @@ jobs:
           path: ${{ runner.temp }}/hugo_cache
           key: ${{ steps.cache-restore.outputs.cache-primary-key }}
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          include-hidden-files: false
-          path: ./public
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
+      - name: Disable Jekyll processing
+        # Branch-source Pages runs the published output through Jekyll unless
+        # this file exists, which strips files and directories beginning with
+        # an underscore.
+        run: touch public/.nojekyll
+
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v5
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: public
+          # Production owns the branch root but must leave PR previews alone.
+          # (No previews exist yet; this keeps the deploy forward-compatible.)
+          clean-exclude: pr-preview/
+          # Force-pushing would clobber anything deployed to the branch since
+          # this build started; rebase onto it instead.
+          force: false


### PR DESCRIPTION
From Human:

Preparing to set up gh-pages deployment previews for each PR without needing an external service like Netlify.
This PR first sets up the gh-pages branch and deployment using gh-pages (currently directly uses actions deployment).

---

From Claude:

Switches production deployment from GitHub Pages' **GitHub Actions** source (`configure-pages` / `upload-pages-artifact` / `deploy-pages`) to a push to the `gh-pages` branch via `JamesIves/github-pages-deploy-action`.

This is a prerequisite for PR deployment previews (follow-up branch: `pr-previews`). A repository gets one Pages site fed by one source; serving previews from subdirectories of the published site requires the source to be *Deploy from branch*, which is incompatible with artifact publishing.

## What changed

21 lines in `.github/workflows/hugo.yml`. **Build steps are untouched.**

- `permissions` → `contents: write` (publishing is now a push to this repo, not an artifact upload)
- Dropped the `configure-pages` step and the separate `deploy` job
- Dropped `--baseURL` from the build — the value in the site config (`https://ubc-mds.github.io/`) is already correct and no longer needs to come from `configure-pages`
- Added `.nojekyll`, because branch-source Pages runs output through Jekyll otherwise
- `clean-exclude: pr-preview/` and `force: false` aren't needed yet; they make the deploy forward-compatible with previews

## Verification

Built locally with the pinned Hugo `0.164.0+extended` (same version CI installs): **121 pages / 133 HTML files**, identical to the pre-change baseline, with production-rooted URLs.

## Merging this does not change the live site

The Pages source setting still points at the old artifact, so merging only populates the `gh-pages` branch — the live site keeps being served exactly as it is today. That makes the next step verifiable before it takes effect:

1. Merge this PR
2. Confirm the `gh-pages` branch exists and its root has a complete site (`index.html`, `img/`, `.nojekyll`)
3. **Settings → Pages → Source → Deploy from branch → `gh-pages` / `(root)`**
4. Verify: homepage, a nested page (`/capstone/about/`), CSS, an image

**Rollback:** Settings → Pages → Source → GitHub Actions, then re-run the last pre-merge `hugo.yml`. The `gh-pages` branch can be left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)