### PR TITLE
🤖: Add PR deployment previews on GitHub Pages

### DIFF
--- a/.github/actions/build-site/action.yml
+++ b/.github/actions/build-site/action.yml
@@ -1,0 +1,150 @@
+name: Build site
+description: >
+  Install the Hugo toolchain and build the site into ./public. Shared by the
+  production deploy (hugo.yml) and the PR preview build (preview.yml) so the
+  tool version pins below are the single place they are defined.
+
+inputs:
+  base-url:
+    description: >
+      Value for Hugo's --baseURL. Leave empty to use the baseURL configured in
+      hugo.yml (correct for production). PR previews must override this, because
+      Hugo bakes absolute URLs into its output — a preview built with the
+      production baseURL renders using production's assets and links.
+    required: false
+    default: ""
+
+  # Tool versions. Bump them here and both workflows follow.
+  dart-sass-version:
+    description: Dart Sass version to install.
+    required: false
+    default: "1.101.0"
+  go-version:
+    description: Go version to install (only used if go.mod exists).
+    required: false
+    default: "1.26.4"
+  hugo-version:
+    description: Hugo (extended) version to install.
+    required: false
+    default: "0.164.0"
+  node-version:
+    description: Node.js version to install (only used if package-lock.json exists).
+    required: false
+    default: "24.16.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Create a local tools directory
+      shell: bash
+      run: |
+        mkdir -p "${HOME}/.local"
+
+    - name: Install Go
+      if: hashFiles('go.mod') != ''
+      uses: actions/setup-go@v6
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache: false
+
+    - name: Install Node.js
+      if: hashFiles('package-lock.json') != ''
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install Dart Sass
+      shell: bash
+      env:
+        DART_SASS_VERSION: ${{ inputs.dart-sass-version }}
+      run: |
+        echo "Installing Dart Sass ${DART_SASS_VERSION}..."
+        curl -sfL --output-dir "${{ runner.temp }}" -O "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+        tar -C "${HOME}/.local" -xf "${{ runner.temp }}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+        echo "${HOME}/.local/dart-sass" >> "${GITHUB_PATH}"
+
+    - name: Install Hugo
+      shell: bash
+      env:
+        HUGO_VERSION: ${{ inputs.hugo-version }}
+      run: |
+        echo "Installing Hugo ${HUGO_VERSION}..."
+        curl -sfL --output-dir "${{ runner.temp }}" -O "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+        mkdir -p "${HOME}/.local/hugo"
+        tar -C "${HOME}/.local/hugo" -xf "${{ runner.temp }}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+        echo "${HOME}/.local/hugo" >> "${GITHUB_PATH}"
+
+    - name: Log tool versions
+      shell: bash
+      run: |
+        echo "Logging tool versions..."
+        command -v sass &> /dev/null && echo "Dart Sass: $(sass --version)" || echo "Dart Sass: not installed"
+        command -v go &> /dev/null && echo "Go: $(go version)" || echo "Go: not installed"
+        command -v hugo &> /dev/null && echo "Hugo: $(hugo version)" || echo "Hugo: not installed"
+        command -v node &> /dev/null && echo "Node.js: $(node --version)" || echo "Node.js: not installed"
+
+    - name: Configure Git
+      shell: bash
+      run: |
+        echo "Configuring Git..."
+        git config --global core.quotepath false
+
+    - name: Fetch full Git history
+      shell: bash
+      run: |
+        if [[ $(git rev-parse --is-shallow-repository) == true ]]; then
+          echo "Fetching full Git history..."
+          git fetch --unshallow
+        fi
+
+    - name: Initialize Git submodules
+      shell: bash
+      run: |
+        if [[ -f .gitmodules ]]; then
+          echo "Initializing Git submodules..."
+          git submodule update --init --recursive
+        fi
+
+    - name: Install Node.js dependencies
+      shell: bash
+      run: |
+        if [[ -f package-lock.json ]]; then
+          echo "Installing Node.js dependencies..."
+          npm ci
+        fi
+
+    - name: Cache restore
+      id: cache-restore
+      uses: actions/cache/restore@v5
+      with:
+        path: ${{ runner.temp }}/hugo_cache
+        key: hugo-${{ github.run_id }}
+        restore-keys: hugo-
+
+    - name: Build
+      shell: bash
+      env:
+        # Dates rendered into the site are built in the program's local time.
+        TZ: America/Vancouver
+        BASE_URL: ${{ inputs.base-url }}
+      run: |
+        echo "Building the project..."
+        args=(--gc --minify --cacheDir "${{ runner.temp }}/hugo_cache")
+        if [[ -n "${BASE_URL}" ]]; then
+          echo "Overriding baseURL: ${BASE_URL}"
+          args+=(--baseURL "${BASE_URL}")
+        fi
+        hugo build "${args[@]}"
+
+    - name: Cache save
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ runner.temp }}/hugo_cache
+        key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+
+    - name: Disable Jekyll processing
+      shell: bash
+      # Pages serves the gh-pages branch through Jekyll unless this file exists,
+      # which strips files and directories beginning with an underscore.
+      run: |
+        touch public/.nojekyll

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -17,15 +17,6 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      # Define tool versions
-      DART_SASS_VERSION: 1.101.0
-      GO_VERSION: 1.26.4
-      HUGO_VERSION: 0.164.0
-      NODE_VERSION: 24.16.0
-
-      # Set the build time zone
-      TZ: America/Vancouver
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -33,101 +24,9 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Create a local tools directory
-        run: |
-          mkdir -p "${HOME}/.local"
-
-      - name: Install Go
-        if: hashFiles('go.mod') != ''
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: false
-
-      - name: Install Node.js
-        if: hashFiles('package-lock.json') != ''
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install Dart Sass
-        run: |
-          echo "Installing Dart Sass ${DART_SASS_VERSION}..."
-          curl -sfL --output-dir "${{ runner.temp }}" -O "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-          tar -C "${HOME}/.local" -xf "${{ runner.temp }}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-          echo "${HOME}/.local/dart-sass" >> "${GITHUB_PATH}"
-
-      - name: Install Hugo
-        run: |
-          echo "Installing Hugo ${HUGO_VERSION}..."
-          curl -sfL --output-dir "${{ runner.temp }}" -O "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
-          mkdir "${HOME}/.local/hugo"
-          tar -C "${HOME}/.local/hugo" -xf "${{ runner.temp }}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
-          echo "${HOME}/.local/hugo" >> "${GITHUB_PATH}"
-
-      - name: Log tool versions
-        run: |
-          echo "Logging tool versions..."
-          command -v sass &> /dev/null && echo "Dart Sass: $(sass --version)" || echo "Dart Sass: not installed"
-          command -v go &> /dev/null && echo "Go: $(go version)" || echo "Go: not installed"
-          command -v hugo &> /dev/null && echo "Hugo: $(hugo version)" || echo "Hugo: not installed"
-          command -v node &> /dev/null && echo "Node.js: $(node --version)" || echo "Node.js: not installed"
-
-      - name: Configure Git
-        run: |
-          echo "Configuring Git..."
-          git config --global core.quotepath false
-
-      - name: Fetch full Git history
-        run: |
-          if [[ $(git rev-parse --is-shallow-repository) == true ]]; then
-            echo "Fetching full Git history..."
-            git fetch --unshallow
-          fi
-
-      - name: Initialize Git submodules
-        run: |
-          if [[ -f .gitmodules ]]; then
-            echo "Initializing Git submodules..."
-            git submodule update --init --recursive
-          fi
-
-      - name: Install Node.js dependencies
-        run: |
-          if [[ -f package-lock.json ]]; then
-            echo "Installing Node.js dependencies..."
-            npm ci
-          fi
-
-      - name: Cache restore
-        id: cache-restore
-        uses: actions/cache/restore@v5
-        with:
-          path: ${{ runner.temp }}/hugo_cache
-          key: hugo-${{ github.run_id }}
-          restore-keys: hugo-
-
-      - name: Build
-        # No --baseURL: the value configured in hugo.yml (site config) is already
-        # correct for production, and no longer needs to come from configure-pages.
-        run: |
-          echo "Building the project..."
-          hugo build \
-            --gc \
-            --minify \
-            --cacheDir "${{ runner.temp }}/hugo_cache"
-
-      - name: Cache save
-        uses: actions/cache/save@v5
-        with:
-          path: ${{ runner.temp }}/hugo_cache
-          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
-
-      - name: Disable Jekyll processing
-        # Branch-source Pages runs the published output through Jekyll unless
-        # this file exists, which strips files and directories beginning with
-        # an underscore.
-        run: touch public/.nojekyll
+      - name: Build site
+        uses: ./.github/actions/build-site
+        # No base-url: production uses the baseURL configured in hugo.yml.
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
@@ -135,8 +34,7 @@ jobs:
           branch: gh-pages
           folder: public
           # Production owns the branch root but must leave PR previews alone.
-          # (No previews exist yet; this keeps the deploy forward-compatible.)
           clean-exclude: pr-preview/
-          # Force-pushing would clobber anything deployed to the branch since
-          # this build started; rebase onto it instead.
+          # Force-pushing would clobber previews deployed since this build
+          # started; rebase onto them instead.
           force: false

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,76 @@
+# PR deployment previews — GitHub-native replacement for Netlify previews.
+#
+# Each PR's rendered site is deployed to the gh-pages branch under
+# pr-preview/pr-<N>/ and announced by a sticky comment. The preview is removed
+# when the PR closes. Build steps are shared with the production deploy via
+# .github/actions/build-site, so the two cannot drift apart.
+#
+# Production (hugo.yml) deploys with clean-exclude: pr-preview/ and force: false
+# so that publishing main does not delete open previews.
+name: PR Preview
+on:
+  pull_request:
+    # 'closed' is not a default pull_request type and must be listed explicitly,
+    # otherwise previews are deployed but never cleaned up.
+    types: [opened, reopened, synchronize, closed]
+# One preview build per PR; a new push supersedes an in-flight build.
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: bash
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push preview files to gh-pages
+      pull-requests: write   # sticky preview comment
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        # Same checkout inputs as hugo.yml: the theme is a submodule, and the
+        # point of a preview is that it is built exactly like production.
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      # Build steps are skipped when the PR closes — the deploy step below still
+      # runs, and is what removes the preview directory.
+      - name: Build site
+        if: github.event.action != 'closed'
+        uses: ./.github/actions/build-site
+        with:
+          # Hugo writes absolute URLs based on baseURL. Without this override the
+          # preview would render using production's assets and internal links —
+          # it would look right while actually being the live site.
+          base-url: https://ubc-mds.github.io/pr-preview/pr-${{ github.event.number }}/
+
+      - name: Prevent search engines from indexing previews
+        if: github.event.action != 'closed'
+        # Previews share an origin with the real program site, so a crawler could
+        # surface a draft page in search results for the live program. robots.txt
+        # cannot help: it is only honoured at the domain root, which production
+        # owns. Injecting the meta tag per page is the only lever available.
+        run: |
+          count=$(find public -name '*.html' | wc -l)
+          find public -name '*.html' -print0 \
+            | xargs -0 sed -i 's|<head>|<head><meta name="robots" content="noindex,nofollow">|'
+          stamped=$(grep -rl 'name="robots" content="noindex,nofollow"' public --include='*.html' | wc -l)
+          echo "Stamped noindex into ${stamped} of ${count} HTML files"
+          if [[ "${stamped}" -ne "${count}" ]]; then
+            echo "::error::noindex injection missed $(( count - stamped )) file(s)"
+            exit 1
+          fi
+
+      # auto = deploy on opened/reopened/synchronize, remove on closed
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: public
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto
+          # Post the comment only once the preview is actually reachable, so
+          # reviewers never click through to a 404 mid-deploy.
+          wait-for-pages-deployment: true


### PR DESCRIPTION
From Human:

Implements the actual actions for PR deployment previews. The extra changes are different from the Quarto deployment previews because this site is using Hugo.

---

From Claude:

Every pull request gets a live URL rendering that PR's version of the site at https://ubc-mds.github.io/pr-preview/pr-<N>/, announced by a sticky comment and removed when the PR closes. This is what Netlify deploy previews would provide, using only GitHub Pages.

Two changes:

1. The Hugo build moves from hugo.yml into a composite action at .github/actions/build-site. Both workflows call it, so the tool version pins live in exactly one place -- c6ca362 bumped Hugo/Go/Node/Dart Sass, and with duplicated workflows that bump would have to be applied twice or production and preview builds would silently drift apart. A composite action rather than a reusable workflow because it runs in the same job, so public/ is already on disk for the deploy step instead of needing an artifact round trip.

   The steps are moved verbatim. The only behaviour changes are an optional --baseURL (passed only when the input is non-empty) and TZ scoped to the build step, which is the only step that renders dates.

2. preview.yml builds the PR with rossjrw/pr-preview-action handling deploy, cleanup and the comment.

Two details that are load-bearing:

- The --baseURL override is mandatory. Hugo bakes absolute URLs into its output, so a preview built with the production baseURL renders using production's assets and internal links: it looks correct while actually being the live site.

- Previews get a noindex meta tag injected. They share an origin with the real program site, so a crawler could surface a draft course description in search results for the actual program. robots.txt cannot help -- it is only honoured at the domain root, which production owns.

Verified locally with the pinned Hugo 0.164.0+extended: preview build produces the same 121 pages / 133 HTML files as production, all 133 carry the robots tag, and generated URLs are rooted at the preview path.

Known limitation: ~24 hardcoded https://ubc-mds.github.io/ links in content navigate to the live site from inside a preview. Pre-existing; previews merely expose it.

Requires Settings -> Pages -> Source to already be gh-pages / (root). Merging before that flip deploys previews to a branch nobody serves.